### PR TITLE
Update v0.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,8 +69,8 @@ nbproject/
 *.swp
 *.swo
 
-# Local project-specific notes
-support/ # Ignore support folder for local notes and tasks
+# Local project-specific notes and tasks
+support/
 
 # Build directories and files
 build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### Version 0.1.2 - 13-Sep 2024
+
+- **.gitignore Refinement:**
+  - Removed the inline comment next to the `support/` directory entry in `.gitignore` to ensure proper exclusion of the folder from tracking. This update improves clarity and prevents issues with folder exclusion for local project-specific notes.
+
+These minor improvements enhance the functionality of the `.gitignore` file, ensuring that the repository structure remains clean and that local files are appropriately ignored.
+
 ### Version 0.1.1 - 13-Sep 2024
 
 - **.gitignore Enhancements:**


### PR DESCRIPTION
This pull request removes the inline comment next to the `support/` directory in the `.gitignore` file. The adjustment ensures that the folder is properly excluded from Git tracking, preventing potential issues with local project-specific notes being unintentionally committed.