### PR TITLE
[0.1.0] Initial project template with docs and Roxy Engine submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "source/libraries/roxy"]
+	path = source/libraries/roxy
+	url = https://github.com/invisiblesloth/roxy-engine.git

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,36 @@
+Licenses
+
+--
+
+Roxy Engine Project Template
+
+MIT License
+
+Copyright (c) 2024 Invisible Sloth, LLC; Jason Kisner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next
+paragraph) shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--
+
+Roxy Engine License
+
+This template uses the Roxy Game Engine as a submodule. The Roxy Game
+Engine is licensed under the MIT License. Please refer to the `roxy-engine`
+repository for its full license information.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ The fast way to start building Playdate games using [Roxy](https://github.com/in
 1. Click the "Use this template" button above.
 2. Choose "Create a new repository".
 3. Name your project and select visibility (public/private).
-4. Close your new repository locally:
+4. Clone your new repository locally:
    ```bash
-   git clone --recurse-submodules https://github.com/your-username/your-new-repo
+   git clone --recurse-submodules https://github.com/your-username/your-new-repo.git
    ```
 
 > 💡 The `--recurse-submodules` flag makes sure that Roxy Engine is cloned into `source/libraries/`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Roxy Engine Project Template
+
+The fast way to start building Playdate games using [Roxy](https://github.com/invisiblesloth/roxy-engine). This project template includes the engine as a submodule, a recommended folder structure, and a ~~working~~ *soon to be working* build setup to get your going.
+
+> **Note:** Roxy is currently in pre-release. Features and APIs may evolve before version 1.0.
+
+---
+
+## Setup ⚙️
+
+### Create Your Project (Recommended)
+
+1. Click the "Use this template" button above.
+2. Choose "Create a new repository".
+3. Name your project and select visibility (public/private).
+4. Close your new repository locally:
+   ```bash
+   git clone --recurse-submodules https://github.com/your-username/your-new-repo
+   ```
+
+> 💡 The `--recurse-submodules` flag makes sure that Roxy Engine is cloned into `source/libraries/`.
+
+### Manual Download
+
+If you're not using Git:
+
+1. Download this repository as ZIP file and extract it.
+2. Also download [Roxy Engine](https://github.com/invisiblesloth/roxy-engine) and place it in `source/libraries/`.
+
+## Support 💬
+
+Questions or feedback? Contact us at [support@invisiblesloth.com](mailto:support@invisiblesloth.com). We would love to hear about your experience using Roxy!
+
+## License ✅
+
+This project is licensed under the MIT License.
+
+[👉 Details](./LICENSE)
+
+---
+
+*Thanks for your interest and support!*


### PR DESCRIPTION
### Overview
This release adds the initial scaffolding and Roxy Engine submodule.

### Key Changes
- Added initial `README.md` with setup instructions.
- Added initial `LICENSE` (MIT).
- Set up `roxy-engine` as a submodule in `source/libraries/roxy/`.