### PR TITLE
[0.8.0] - Bump Engine, Improve Build Structure, and Show Delta Time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,18 @@ endif
 # List source lookup paths
 VPATH +=  \
           source/libraries/roxy \
-          source/libraries/roxy/utilities \
-          source/libraries/roxy/core/sequences
+          source/libraries/roxy/core/animations \
+          source/libraries/roxy/core/modules \
+          source/libraries/roxy/core/sequences \
+          source/libraries/roxy/utilities
 
 # List C source files here
 SRC =   \
         source/libraries/roxy/roxy.c \
-        source/libraries/roxy/utilities/roxy_math.c \
+        source/libraries/roxy/core/animations/roxy_animation.c \
+        source/libraries/roxy/core/modules/roxy_input.c \
+        source/libraries/roxy/core/sequences/roxy_sequence.c \
         source/libraries/roxy/utilities/roxy_ease.c \
-        source/libraries/roxy/core/sequences/roxy_sequence.c
+        source/libraries/roxy/utilities/roxy_math.c
 
 include $(SDK)/C_API/buildsupport/common.mk

--- a/source/scenes/ExampleScene.lua
+++ b/source/scenes/ExampleScene.lua
@@ -18,5 +18,5 @@ local scene = ExampleScene
 
 function scene:update(dt)
   drawText("This is an example scene.", 20, 20)
-  print(dt)
+  drawText("Delta Time: " .. dt, 20, 50)
 end


### PR DESCRIPTION
### Overview
This update brings the project template in sync with `roxy-engine` v0.8.0, introducing support for new asset management features and improving project usability. It also updates the build system and the example scene to display delta time directly on screen.

### Key Changes
- Updated `roxy-engine` submodule to v0.8.0 for asset pooling and caching support
- Update Makefile with updated VPATH entries for new core module structure
- Updated `ExampleScene` to display delta time on screen instead of logging to console

### Challenges/Notes
- Submodule update enables use of `Assets` and `Cache` modules in new projects