### PR TITLE
[0.10.0] - Bump Engine and Enable Particle and Audio Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ VPATH +=  \
           source/libraries/roxy/core/animations \
           source/libraries/roxy/core/modules \
           source/libraries/roxy/core/sequences \
+          source/libraries/roxy/core/sprites \
           source/libraries/roxy/utilities
 
 # List C source files here
@@ -26,6 +27,7 @@ SRC =   \
         source/libraries/roxy/core/animations/roxy_animation.c \
         source/libraries/roxy/core/modules/roxy_input.c \
         source/libraries/roxy/core/sequences/roxy_sequence.c \
+        source/libraries/roxy/core/sprites/roxy_particles.c \
         source/libraries/roxy/utilities/roxy_ease.c \
         source/libraries/roxy/utilities/roxy_math.c
 


### PR DESCRIPTION
### Overview
This update syncs the project template with `roxy-engine` v0.10.0, unlocking native C-based particle systems and robust audio support through the new `roxy.Music` and `roxy.Sounds` modules. It also updates the build system to compile the newly added particle backend.

### Key Changes
- Updated `roxy-engine` submodule to v0.10.0, which includes:
  - Native C backend for `RoxyParticles`
  - `roxy.Music` and `roxy.Sounds` for audio playback, control, fading, and muting
  - `roxy.Math.clampi` for clamping integer values
  - Tagged logging in `Debug.lua` for clearer debug output
- Updated Makefile:
  - Added `roxy_particles.c` to `SRC` and `VPATH` for correct compilation

### Challenges/Notes
- Template now fully supports engine-level features added in v0.10.0, enabling developers to build projects with native particles and audio without additional setup