### PR TITLE
[0.11.0] - Bump Roxy Engine, Add C Transitions, Clarify License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -34,3 +34,11 @@ SOFTWARE.
 This project uses the Roxy Game Engine as a Git submodule. The engine is
 licensed under the MIT License. Please refer to the Roxy Engine repository for
 full license terms, including third-party attributions and inspirations.
+
+---
+
+## Note to Users
+
+This template is licensed under the MIT License to give you maximum freedom.
+
+When creating your own project using this template, you are free to replace or modify this license to suit your needs.

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ VPATH +=  \
           source/libraries/roxy/core/modules \
           source/libraries/roxy/core/sequences \
           source/libraries/roxy/core/sprites \
+          source/libraries/roxy/core/transitions \
           source/libraries/roxy/utilities
 
 # List C source files here
@@ -28,6 +29,7 @@ SRC =   \
         source/libraries/roxy/core/modules/roxy_input.c \
         source/libraries/roxy/core/sequences/roxy_sequence.c \
         source/libraries/roxy/core/sprites/roxy_particles.c \
+        source/libraries/roxy/core/transitions/roxy_transition.c \
         source/libraries/roxy/utilities/roxy_ease.c \
         source/libraries/roxy/utilities/roxy_math.c
 


### PR DESCRIPTION
### Overview
This release updates the Roxy Engine submodule to v0.11.0, introducing a unified transition system, a new configuration architecture, enhanced asset pooling, and performance improvements. It also updates the Makefile to support C-backed transitions and clarifies licensing guidance for developers using the template.

### Key Changes
- Updated `roxy-engine` submodule to v0.11.0:
  - Introduces structured transition lifecycle (`_onStart`, `_onComplete`, etc.)
  - Adds C-backed transitions: `CrossDissolve`, `FadeToColor`, `ImageTable`
  - Implements layered config system with `ConfigBuilder` and runtime overrides
  - Improves asset pooling with `AssetPoolRegistry` and new helpers
  - Centralizes setup using `roxy.new()`
  - Enhances debug logging and math utility documentation
- Updated Makefile to support new transition system:
  - Added `roxy_transition.c` to source list
  - Included `transitions` directory in `VPATH`
- Clarified licensing expectations in `LICENSE`:
  - Added note that users are free to change or replace the license when using the template for their own projects

### Challenges/Notes
- Transition API changes are **breaking**:
  - All transitions must extend `RoxyTransition` and use a unified `opts` table
  - Legacy transitions (e.g. `FadeToBlack`) have been removed
  - Scene switching methods now require the new options-based signature