### PR TITLE
[0.14.1] - Enable Chunked Tilemap Prerendering and Native Renderer Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ VPATH +=  \
           source/libraries/roxy/core/animations \
           source/libraries/roxy/core/sequences \
           source/libraries/roxy/core/sprites \
+          source/libraries/roxy/core/tilemaps \
           source/libraries/roxy/core/transitions \
           source/libraries/roxy/utilities
 
@@ -27,6 +28,7 @@ SRC =   \
         source/libraries/roxy/core/animations/roxy_animation.c \
         source/libraries/roxy/core/sequences/roxy_sequence.c \
         source/libraries/roxy/core/sprites/roxy_particles.c \
+        source/libraries/roxy/core/tilemaps/roxy_tileRenderer.c \
         source/libraries/roxy/core/transitions/roxy_transition.c \
         source/libraries/roxy/utilities/roxy_ease.c \
         source/libraries/roxy/utilities/roxy_math.c


### PR DESCRIPTION
### Overview
This release updates the `roxy-engine` submodule to v0.14.1 and wires up the native tilemap renderer in the project template. The engine upgrade brings chunk-based prerendering across all tilemap types, improved transition redraw behavior, and caching optimizations for faster rendering. The build changes ensure native tilemap features are compiled and available by default.

### Key Changes
- Updated `roxy-engine` to v0.14.1
  - Added support for chunk-based prerendering in all tilemap types
  - Introduced redraw APIs to improve transition behavior and visual consistency
  - Applied internal caching optimizations to reduce allocations and boost render performance
  - Included asset cache utilities and fixes for native rendering stability
- Added `roxy_tileRenderer.c` to `SRC` and its directory to `VPATH` so native tilemap rendering is compiled into the project

### Breaking Changes ⚠️
- The underlying `roxy-engine` submodule was upgraded to v0.14.1, which introduces breaking changes:
  - Tilemaps using chunked prerendering require manual draw list updates after layer  reordering or tile edits
  - `setTileAt` now enforces bounds and syncs with native renderers; direct writes to   `tilesFlat` are no longer supported
  - World sizing uses projection-aware math; some tilemap layer internals were renamed
  - Object layer parallax properties are case-sensitive and must use exact casing
  - Internal helper functions are now prefixed with underscores to indicate private scope