### PR TITLE
[0.14.4] - Bump roxy-engine; heapguard, sequencer & particles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,57 @@ ifeq ($(SDK),)
 $(error SDK path not found; set ENV value PLAYDATE_SDK_PATH)
 endif
 
-# List source lookup paths
+# ------------------------------------------------------------------------------
+# Heap Guard toggle (0=off, 1=on). CLI overrides:
+#   make                 -> HEAP_GUARD=0 (default)
+#   make release         -> HEAP_GUARD=0
+#   make debug           -> HEAP_GUARD=1 (+ debug/asan flags)
+#   make HEAP_GUARD=1    -> guard on for any target
+# ------------------------------------------------------------------------------
+HEAP_GUARD ?= 0
+
+# Convenience targets that forward to 'all' but tweak flags first
+.PHONY: debug release
+debug: HEAP_GUARD=1
+debug: EXTRA_DEBUG=1
+debug: all
+
+release: HEAP_GUARD=0
+release: EXTRA_DEBUG=0
+release: all
+
+# Print build mode once (optional but handy)
+$(info Heap guard: $(HEAP_GUARD))
+$(info Extra debug: $(EXTRA_DEBUG))
+
+# Core flags common to both simulator/device
+USER_CFLAGS += -Wall -Wextra
+
+# Turn heap guard code on when requested
+ifeq ($(HEAP_GUARD),1)
+  USER_CFLAGS += -DROXY_HEAP_GUARD
+endif
+
+# Extra debug tooling only when requested (e.g., `make debug`)
+ifeq ($(EXTRA_DEBUG),1)
+  # Symbols, disable optimizations for clean debugging, keep frame pointers
+  USER_CFLAGS += -g -O0 -fno-omit-frame-pointer
+
+  # Helpful diagnostics (safe everywhere)
+  USER_CFLAGS += -Wcast-align=strict -fno-strict-aliasing
+
+  # Stack protection; -fstack-usage is compile-time only and harmless on both
+  USER_CFLAGS      += -fstack-protector-strong -fstack-usage
+  SIMULATOR_CFLAGS += -fstack-protector-strong
+
+  # AddressSanitizer for SIMULATOR only (fast feedback, not supported on device)
+  SIMULATOR_CFLAGS  += -fsanitize=address
+  SIMULATOR_LDFLAGS += -fsanitize=address
+endif
+
+# ------------------------------------------------------------------------------
+# Source lookup paths
+# ------------------------------------------------------------------------------
 VPATH +=  \
           source/libraries/roxy \
           source/libraries/roxy/core/animations \
@@ -22,7 +72,9 @@ VPATH +=  \
           source/libraries/roxy/core/transitions \
           source/libraries/roxy/utilities
 
-# List C source files here
+# ------------------------------------------------------------------------------
+# C sources
+# ------------------------------------------------------------------------------
 SRC =   \
         source/libraries/roxy/roxy.c \
         source/libraries/roxy/core/animations/roxy_animation.c \
@@ -31,6 +83,7 @@ SRC =   \
         source/libraries/roxy/core/tilemaps/roxy_tileRenderer.c \
         source/libraries/roxy/core/transitions/roxy_transition.c \
         source/libraries/roxy/utilities/roxy_ease.c \
+        source/libraries/roxy/utilities/roxy_heapguard.c \
         source/libraries/roxy/utilities/roxy_math.c
 
 include $(SDK)/C_API/buildsupport/common.mk


### PR DESCRIPTION
### Overview
This release updates the **Roxy Engine Project Template** to **v0.14.4** by bumping the `roxy-engine` submodule. It introduces `roxy_heapguard` for debug memory instrumentation, expands sequencer capabilities with fractional loops and deterministic completion, improves particle emitter tracking, and strengthens tilemap rendering safety. Additional changes include streamlined core code (`roxy.lua`), buffer validation improvements, and a build flag for toggling heap guard in debug vs. release.

### Key Changes
- **Upgrade to Roxy Engine v0.14.4**
  - Added `roxy_heapguard` for debug memory instrumentation
  - Sequencer improvements: fractional loops, deterministic completion, ordered segments
  - Particle emitter tracking improvements and safer tilemap rendering
  - Performance optimizations in sequencers and particles
  - Bug fixes across buffer validation, graphics, and utilities
- **Breaking changes (from upstream)**
  - Sequences: removed `__newindex` assignment, require `setEasingAt` and ordered segments; updated loop/again/reverse semantics
  - Particles: `spawnMultiple` returns integer (not boolean), dropped `frameCount` param, iteration via `activeCount`, internal frames are 0-based
- Build: new **HEAP_GUARD** flag with debug/release targets for toggling memory instrumentation

### Challenges/Notes
- **Migration:** Projects upgrading to v0.14.4 must refactor sequence setup and particle usage per the new APIs
- **Heap guard impact:** Debug builds with heap guard and sanitizers may run slower but catch memory issues earlier
- **Sequencer validation:** Loop/reverse timing changes require re-testing for desired animation behaviors